### PR TITLE
Hide declare-conflict button for submission authors

### DIFF
--- a/src/routes/[[lang]]/venue/[venueid]/submissions/+page.svelte
+++ b/src/routes/[[lang]]/venue/[venueid]/submissions/+page.svelte
@@ -238,7 +238,7 @@
 							<td>
 								<Column>
 									<SubmissionPreview {submission} />
-									{#if uid && conflicts !== null && !conflicts.some((c) => c.scholarid === uid && c.submissionid === submission.id) && assignments !== null && !assignments.some((a) => a.submission === submission.id && a.scholar === uid)}
+									{#if uid && conflicts !== null && !conflicts.some((c) => c.scholarid === uid && c.submissionid === submission.id) && !submission.authors.includes(uid) && assignments !== null && !assignments.some((a) => a.submission === submission.id && a.scholar === uid)}
 										<Button
 											strings={(l) => l.page.submissions.button.declareConflict}
 											action={() =>


### PR DESCRIPTION
## Summary
- On the submissions page, hide the "Declare conflict" button when the current scholar is an author of the submission, since authors are inherently conflicted with their own submissions.

The button already hid itself for scholars with a previously declared conflict (and `sortedAndFiltered` filters those submissions out entirely), but authors of a submission still saw the button on their own submissions.

## Test plan
- [ ] As an author of a submission, view the venue's submissions page and verify the "Declare conflict" button does not appear on the row for your own submission.
- [ ] As a non-author scholar without any declared conflicts, verify the "Declare conflict" button still appears.
- [ ] As a scholar already assigned to a submission, verify the button still does not appear (existing behavior).

https://claude.ai/code/session_01Lm3kHrSMxNAjcG8K9KZNnE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm3kHrSMxNAjcG8K9KZNnE)_