### PR TITLE
Added end-to-end test for paper bidding by a reviewer.

### DIFF
--- a/end2end/submissions.end.ts
+++ b/end2end/submissions.end.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import { login, logout } from '../src/routes/login';
+
+test('a reviewer can bid on a paper and then see an unbid button', async ({ page, context }) => {
+	await login('r1@uni.edu', page, context);
+
+	await page.goto('/venue/c60d7d0a-ad37-11f0-83e5-efb2eb8bdbd6/submissions');
+
+	// Bid on the first paper that has a bid button.
+	const firstBidButton = page.getByTestId(/^bid-/).first();
+	await expect(firstBidButton, 'Expect a bid button to be visible').toBeVisible();
+	await firstBidButton.click();
+
+	// After bidding, an unbid button should appear.
+	await expect(
+		page.getByTestId(/^unbid-/).first(),
+		'Expect an unbid button to appear after bidding'
+	).toBeVisible();
+
+	await logout(page);
+});

--- a/end2end/submissions.end.ts
+++ b/end2end/submissions.end.ts
@@ -5,6 +5,7 @@ test('a reviewer can bid on a paper and then see an unbid button', async ({ page
 	await login('r1@uni.edu', page, context);
 
 	await page.goto('/venue/c60d7d0a-ad37-11f0-83e5-efb2eb8bdbd6/submissions');
+	await page.waitForLoadState('networkidle');
 
 	// Bid on the first paper that has a bid button.
 	const firstBidButton = page.getByTestId(/^bid-/).first();

--- a/end2end/venue.end.ts
+++ b/end2end/venue.end.ts
@@ -29,25 +29,6 @@ test('a volunteer should see they have volunteered', async ({ page, context }) =
 	await logout(page);
 });
 
-test('a reviewer can bid on a paper and then see an unbid button', async ({ page, context }) => {
-	await login('r1@uni.edu', page, context);
-
-	await page.goto('/venue/c60d7d0a-ad37-11f0-83e5-efb2eb8bdbd6/submissions');
-
-	// Bid on the first paper that has a bid button.
-	const firstBidButton = page.getByTestId(/^bid-/).first();
-	await expect(firstBidButton, 'Expect a bid button to be visible').toBeVisible();
-	await firstBidButton.click();
-
-	// After bidding, an unbid button should appear.
-	await expect(
-		page.getByTestId(/^unbid-/).first(),
-		'Expect an unbid button to appear after bidding'
-	).toBeVisible();
-
-	await logout(page);
-});
-
 test('an editor should see editor specific things', async ({ page, context }) => {
 	await login('editor@uni.edu', page, context);
 

--- a/end2end/venue.end.ts
+++ b/end2end/venue.end.ts
@@ -29,6 +29,25 @@ test('a volunteer should see they have volunteered', async ({ page, context }) =
 	await logout(page);
 });
 
+test('a reviewer can bid on a paper and then see an unbid button', async ({ page, context }) => {
+	await login('r1@uni.edu', page, context);
+
+	await page.goto('/venue/c60d7d0a-ad37-11f0-83e5-efb2eb8bdbd6/submissions');
+
+	// Bid on the first paper that has a bid button.
+	const firstBidButton = page.getByTestId(/^bid-/).first();
+	await expect(firstBidButton, 'Expect a bid button to be visible').toBeVisible();
+	await firstBidButton.click();
+
+	// After bidding, an unbid button should appear.
+	await expect(
+		page.getByTestId(/^unbid-/).first(),
+		'Expect an unbid button to appear after bidding'
+	).toBeVisible();
+
+	await logout(page);
+});
+
 test('an editor should see editor specific things', async ({ page, context }) => {
 	await login('editor@uni.edu', page, context);
 

--- a/src/routes/[[lang]]/venue/[venueid]/submissions/+page.svelte
+++ b/src/routes/[[lang]]/venue/[venueid]/submissions/+page.svelte
@@ -240,7 +240,7 @@
 							<td>{submission.expertise}</td>
 							<td>{submission.externalid}</td>
 							<!-- If we have all the information, show metadata about bidding. -->
-							{#each visibleRoles as role}
+							{#each visibleRoles as role, roleIndex}
 								<!-- This cell should show all actions available for this role and submission, based on the current scholar's role. -->
 								<td>
 									<Column>
@@ -279,6 +279,7 @@
 													{#if scholarsBid === undefined}
 														<!-- No assignments? Allow bidding -->
 														<Button
+															testid={`bid-${index}-${roleIndex}`}
 															strings={(l) => ({
 																tip: l.page.submissions.button.bid.tip.replace(
 																	'{role}',
@@ -292,6 +293,7 @@
 													{:else if scholarsBid !== undefined && !scholarsBid.approved}
 														<!-- Shown an unbid button if not yet approved -->
 														<Button
+															testid={`unbid-${index}-${roleIndex}`}
 															strings={(l) => ({
 																tip: l.page.submissions.button.unbid.tip.replace(
 																	'{role}',


### PR DESCRIPTION
Added testids to the bid and unbid buttons on the submissions page so the new test (and future tests) can target them without depending on button labels.