### PR TITLE
Fix page header disappearing when navigating by hash

### DIFF
--- a/src/lib/components/Page.svelte
+++ b/src/lib/components/Page.svelte
@@ -50,7 +50,8 @@
 		pageHeader.edit = undefined;
 	}
 
-	beforeNavigate(() => {
+	beforeNavigate(({ from, to }) => {
+		if (from?.route.id === to?.route.id) return;
 		cleanupContext();
 	});
 

--- a/src/lib/components/Page.svelte
+++ b/src/lib/components/Page.svelte
@@ -51,7 +51,13 @@
 	}
 
 	beforeNavigate(({ from, to }) => {
-		if (from?.route.id === to?.route.id) return;
+		if (
+			from &&
+			to &&
+			from.url.pathname === to.url.pathname &&
+			from.url.search === to.url.search
+		)
+			return;
 		cleanupContext();
 	});
 


### PR DESCRIPTION
The beforeNavigate hook was clearing the page header for all navigation events, including hash-only changes (like clicking dashboard stats to anchor scroll to sections). Now it only clears when actually changing routes, preserving the header during in-page navigation.