### PR TITLE
Fixes found while verifying staging

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -91,6 +91,22 @@
 				--page-width: 45rem;
 			}
 
+			/*
+			 * The nav header and the footer are both `position: sticky`, so they overlay
+			 * whatever the page scrolls under them. Reserve that space on the scrollport so
+			 * anything scrolled to — an anchor link beside a heading, or an element a test
+			 * or the browser scrolls into view — lands in the visible band between them
+			 * rather than underneath. Without this, a control near the end of a long page
+			 * can sit permanently beneath the footer: visible, but impossible to click.
+			 *
+			 * The start value covers the nav plus up to three stacked banners (beta, test
+			 * environment, unverified email), which is the tallest the header gets.
+			 */
+			html {
+				scroll-padding-block-start: 14rem;
+				scroll-padding-block-end: 5rem;
+			}
+
 			body {
 				background: var(--background-color);
 				color: var(--text-color);

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -24,11 +24,22 @@ export const handle: Handle = async ({ event, resolve }) => {
 			 * will replicate previous/standard behaviour (https://kit.svelte.dev/docs/types#public-types-cookies)
 			 */
 			setAll: (cookiesToSet, headers) => {
-				cookiesToSet.forEach(({ name, value, options }) => {
-					event.cookies.set(name, value, { ...options, path: '/' });
-				});
-				if (Object.keys(headers).length > 0) {
-					event.setHeaders(headers);
+				// Supabase can refresh a token asynchronously — `_notifyAllSubscribers` resolving
+				// after the handler returned — and SvelteKit throws if cookies are set once the
+				// response has been generated. That throw surfaces inside a promise nobody
+				// awaits, so it becomes an unhandled rejection and takes the whole Node process
+				// down; in `vite preview` that kills the server outright. There is nothing to do
+				// about a session written too late: the response is already on its way, and the
+				// client refreshes again on the next request. So swallow it rather than crash.
+				try {
+					cookiesToSet.forEach(({ name, value, options }) => {
+						event.cookies.set(name, value, { ...options, path: '/' });
+					});
+					if (Object.keys(headers).length > 0) {
+						event.setHeaders(headers);
+					}
+				} catch {
+					// Response already sent; see above.
 				}
 			}
 		}

--- a/src/lib/components/VerifyEmail.svelte
+++ b/src/lib/components/VerifyEmail.svelte
@@ -22,6 +22,34 @@
 
 	let valid = $derived(validEmail(email));
 
+	/**
+	 * Map the failure the database reported onto something the scholar can act on.
+	 *
+	 * `request_email_verification` distinguishes four causes and tags each with a `hint`
+	 * (see supabase/schemas/email_verifications.sql), which PostgREST returns in the error
+	 * body. We key off that rather than the message text so wording and localization stay
+	 * free to change. Anything unrecognized falls back to the generic message — a new
+	 * failure mode should read as a generic fault, never as the wrong specific one.
+	 */
+	function errorFor(result: Result): (l: LocaleText) => string {
+		const details = result.error?.details as { hint?: string; code?: string } | undefined;
+		switch (details?.hint) {
+			case 'cooldown':
+				return (l) => l.component.verifyEmail.feedback.cooldown;
+			case 'not_configured':
+				return (l) => l.component.verifyEmail.feedback.notConfigured;
+			case 'auth_required':
+				return (l) => l.component.verifyEmail.feedback.signedOut;
+			case 'invalid_email':
+				return (l) => l.component.verifyEmail.field.email.invalid;
+		}
+		// A caller with no valid session never reaches the function's own auth check: EXECUTE
+		// is revoked from anon, so Postgres refuses first and returns 42501 with no hint. That
+		// is the same situation as `auth_required` from the scholar's point of view.
+		if (details?.code === '42501') return (l) => l.component.verifyEmail.feedback.signedOut;
+		return (l) => l.component.verifyEmail.feedback.error;
+	}
+
 	/** Request verification for `target`, recording UI state for the feedback + dev link.
 	 * Returns a plain Result so it can also drive EditableText's `edit`. */
 	async function request(target: string): Promise<Result> {
@@ -41,7 +69,7 @@
 		unchanged = false;
 		const result = await db().requestEmailVerification(trimmed);
 		if (result.error) {
-			error = (l) => l.component.verifyEmail.feedback.error;
+			error = errorFor(result);
 			sent = false;
 			return { error: result.error };
 		}

--- a/src/lib/locales/Locale.ts
+++ b/src/lib/locales/Locale.ts
@@ -1151,8 +1151,16 @@ export type LocaleText = {
 			};
 			feedback: {
 				sent: string;
+				/** Fallback when the server gave no recognizable reason. */
 				error: string;
 				unchanged: string;
+				/** The one-minute rate limit was hit; a link is already on its way. */
+				cooldown: string;
+				/** This deployment has no `site_url` vault secret, so no link can be built.
+				 * A configuration fault, not something the scholar can retry into working. */
+				notConfigured: string;
+				/** The session ended between loading the page and submitting. */
+				signedOut: string;
 			};
 		};
 	};

--- a/src/lib/locales/LocaleText.json
+++ b/src/lib/locales/LocaleText.json
@@ -246,10 +246,23 @@
                 "feedback": {
                   "additionalProperties": false,
                   "properties": {
+                    "cooldown": {
+                      "description": "The one-minute rate limit was hit; a link is already on its way.",
+                      "type": "string"
+                    },
                     "error": {
+                      "description": "Fallback when the server gave no recognizable reason.",
+                      "type": "string"
+                    },
+                    "notConfigured": {
+                      "description": "This deployment has no `site_url` vault secret, so no link can be built. A configuration fault, not something the scholar can retry into working.",
                       "type": "string"
                     },
                     "sent": {
+                      "type": "string"
+                    },
+                    "signedOut": {
+                      "description": "The session ended between loading the page and submitting.",
                       "type": "string"
                     },
                     "unchanged": {
@@ -259,7 +272,10 @@
                   "required": [
                     "sent",
                     "error",
-                    "unchanged"
+                    "unchanged",
+                    "cooldown",
+                    "notConfigured",
+                    "signedOut"
                   ],
                   "type": "object"
                 },

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -80,5 +80,10 @@
 		gap: var(--spacing);
 		margin: auto;
 		max-width: var(--page-width);
+		/* Keep the last of the page's content clear of the sticky footer, which would
+		   otherwise sit directly on top of it. Pairs with the scroll-padding on `html`
+		   in app.html: that governs where scrolling stops, this guarantees there is
+		   somewhere to stop. */
+		padding-block-end: 5rem;
 	}
 </style>

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -786,8 +786,14 @@
 						"label": "Send thanks",
 						"tip": "Share your thanks with this submission's reviewers."
 					},
-					"approve": { "label": "Approve", "tip": "Share this note with the reviewers." },
-					"declineInitiate": { "label": "Decline", "tip": "Decline this note with a reason." },
+					"approve": {
+						"label": "Approve",
+						"tip": "Share this note with the reviewers."
+					},
+					"declineInitiate": {
+						"label": "Decline",
+						"tip": "Decline this note with a reason."
+					},
 					"declineConfirm": {
 						"label": "Confirm decline",
 						"tip": "Decline this note and notify the author."
@@ -997,7 +1003,7 @@
 				"welcome": "Welcome, venue admin! This page walks you through configuring your venue as a sequence of numbered steps. Work through each section in order. Start with **Step 1** below to align on the policies that the rest of the settings encode, then move down the page recording each decision. The last step is always **Activate** — flip the venue on to open it for volunteering.",
 				"policies": "Before changing any settings below, get community alignment on each of these decisions. The settings on this page just encode them; getting them wrong is hard to walk back once volunteers start participating.\n\n- The venue's **purpose and scope** — what topics, what kinds of submissions you accept\n- The **submission types** you'll accept (e.g., full papers, posters, revisions)\n- The **roles** scholars take on (Editor, Associate Editor, Reviewer, …) and how many people each submission needs in each role\n- The other **editors / admins** who can configure this venue with you\n- Which **external reviewing platform** (HotCRP, OJS, ScholarOne, etc.) handles your peer review, so the email-template snippets in Step 6 use the right syntax\n\nThe most consequential choices — the token economy, how reviewing is organized, what counts as a creditable review, and who can mint — are expanded in the cards below.",
 				"economics": "Tokens only work if they stay scarce enough to be worth earning. The economy has two failure modes:\n\n- **Too many tokens** — if welcome gifts are generous and submission costs are low, everyone already has enough to submit, so no one needs to review. Reviewing stalls and quality and timeliness suffer.\n- **Too few tokens** — if costs are high and tokens are hard to earn, authors can't accumulate enough to submit, and publishing slows down.\n\nTwo rules keep you in balance:\n\n1. **Per-role compensation for a submission must sum to no more than its submission cost.** Otherwise every reviewed submission injects net-new tokens and the supply inflates until reviewing has no value.\n2. **Mint tokens roughly in proportion to the number of active scholars**, topping up only as the community grows — not in large speculative batches.\n\n**For example.** A journal pays **10** tokens for a review, **10** for an associate-editor recommendation, and **1** for an editor-in-chief decision: **21** tokens paid out per submission. It sets the **submission cost to 40** (comfortably above the 21 paid out, so the venue reserve grows slightly) and the **welcome gift to 30**, so a newcomer can submit after reviewing just once (30 + 10 = 40). Tune these numbers to your community's reviewing load, but always check the two rules above before you change them.",
-					"anonymityAssignment": "How your community reviews is as consequential as how it pays. Two linked decisions:\n\n- **Anonymity model** — *open* (authors and reviewers see each other), *single-anonymous* (reviewers see authors but not the reverse), or *double-anonymous* (neither sees the other). More anonymity reduces bias but makes conflicts of interest harder to spot; open review increases accountability but can chill candid feedback. You set this per role — Step 4 controls whether authors can see who's assigned, and each role's settings control whether that role sees author identities.\n- **Bidding vs. central assignment** — let reviewers **bid** on what they want to review, or assign work **centrally**. Bidding scales well and surfaces genuine interest; central assignment gives editors tighter control over load and expertise matching. If you enable bidding for a role (Step 3), define the **preference labels** bidders choose from (Step 5), e.g. \"Preferred\" / \"If necessary\".",
+				"anonymityAssignment": "How your community reviews is as consequential as how it pays. Two linked decisions:\n\n- **Anonymity model** — *open* (authors and reviewers see each other), *single-anonymous* (reviewers see authors but not the reverse), or *double-anonymous* (neither sees the other). More anonymity reduces bias but makes conflicts of interest harder to spot; open review increases accountability but can chill candid feedback. You set this per role — Step 4 controls whether authors can see who's assigned, and each role's settings control whether that role sees author identities.\n- **Bidding vs. central assignment** — let reviewers **bid** on what they want to review, or assign work **centrally**. Bidding scales well and surfaces genuine interest; central assignment gives editors tighter control over load and expertise matching. If you enable bidding for a role (Step 3), define the **preference labels** bidders choose from (Step 5), e.g. \"Preferred\" / \"If necessary\".",
 				"minters": "First decide on a **currency** — the shared token economy your venue runs on:\n\n- **Join an existing currency** to share an economy with a related venue (e.g. a sibling conference or journal in the same community). Tokens earned in one venue can then be spent in the other. The existing currency already has its own **minters**, so you don't appoint any — you inherit theirs.\n- **Start your own currency** if your venue's economy should stand alone. Only then do you choose minters.\n\n**Minters** can create new tokens, so choose them as carefully as you choose editors:\n\n- Pick **trusted, long-tenured members** of the community who understand its reviewing economy.\n- Appoint **more than one** so minting doesn't stall if someone steps away (avoid a single point of failure).\n- Choose people **willing to monitor the token supply** and mint gradually as the community grows, rather than in large batches.\n- Make sure they understand the **balance rules** in *Setting welcome & compensation* above — over-minting collapses the same way over-generous welcome gifts do.\n\nMinting happens on the currency page, where the mint form shows a warning about creating too many tokens.",
 				"reviewQuality": "The platform releases compensation when an assignment is marked complete — it does **not** judge whether a review was actually good. That editorial bar is yours to define. Before launch, agree on **what counts as a creditable review** (depth, timeliness, constructiveness) and **who signs off** before tokens are released.\n\nThree existing controls let you enforce that policy:\n\n- **Approver role** (Step 3, per role) — designate which role approves assignments to another role, so a human checks the work before it's credited.\n- **Compensation approval** — compensation transactions are approved before tokens move, giving editors a checkpoint to withhold credit for inadequate reviews.\n- **Vet thank-you notes** (Step 4) — optionally require an admin or editor to approve author thank-you notes before reviewers see them."
 			},
@@ -1053,7 +1059,7 @@
 				"volunteeringFirst": "These are your volunteer roles.",
 				"volunteeringThird": "These are this scholar's volunteer roles.",
 				"noName": "Welcome! Edit your name above to set it, then share your reviewing status below so others know your availability.",
-		"addEmail": "Add a contact email so editors can reach you and you can receive notifications. We'll send a link to verify it, and won't email you anything else until you do."
+				"addEmail": "Add a contact email so editors can reach you and you can receive notifications. We'll send a link to verify it, and won't email you anything else until you do."
 			},
 			"field": {
 				"name": {
@@ -1633,7 +1639,10 @@
 			"feedback": {
 				"sent": "We sent a verification link to {email} (valid 15 minutes). It becomes your contact email once you verify it.",
 				"error": "Unable to send a verification email.",
-				"unchanged": "That's already your contact email — nothing to verify."
+				"unchanged": "That's already your contact email — nothing to verify.",
+				"cooldown": "You just requested a link — check your inbox, or try again in a minute.",
+				"notConfigured": "This site isn't set up to send email yet. Please report this to an administrator.",
+				"signedOut": "You've been signed out. Sign in again to verify your email."
 			}
 		}
 	},

--- a/supabase/migrations/20260720000000_verification_error_hints.sql
+++ b/supabase/migrations/20260720000000_verification_error_hints.sql
@@ -1,0 +1,85 @@
+-- Tag request_email_verification's failures with machine-readable hints.
+--
+-- The RPC already distinguishes four failure modes, but every one of them reached the
+-- interface as the same sentence: "Unable to send a verification email." That is actively
+-- misleading — a scholar told to wait a moment is given no reason to try again, and an
+-- environment missing its `site_url` vault secret looks identical to a transient fault.
+-- This was found while verifying staging, where a missing secret produced a dead end with
+-- nothing to act on.
+--
+-- Each raise now carries `hint`, which PostgREST returns in the error body and supabase-js
+-- exposes as `error.hint`. The interface maps the hint to a specific message and falls back
+-- to the generic one for anything unrecognized. Hints rather than message matching, so the
+-- wording stays free to change (and to be localized) without breaking the mapping, and
+-- rather than custom SQLSTATEs, which PostgREST does not pass through as faithfully.
+
+create or replace function public.request_email_verification (_email text) returns void language "plpgsql" security definer
+set
+	"search_path" to 'public', 'pg_temp' as $$
+declare
+	_caller uuid := (select auth.uid());
+	_token text;
+	_origin text := private.get_secret('site_url');
+	_previous timestamptz;
+begin
+	if _caller is null then
+		raise exception 'Authentication required' using hint = 'auth_required';
+	end if;
+	if _email is null or _email !~ '^.+@.+\..+$' then
+		raise exception 'A valid email address is required' using hint = 'invalid_email';
+	end if;
+	-- A deployment that has not had its `site_url` vault secret set cannot build a
+	-- verification link. Say so, rather than letting it look like a delivery failure.
+	if _origin is null or _origin = '' then
+		raise exception 'The site_url vault secret is not configured' using hint = 'not_configured';
+	end if;
+
+	-- Rate limit. Each call emails an address the caller chose, so without a cooldown this
+	-- RPC is a mail amplifier. One per minute is well below any legitimate resend cadence.
+	select created_at into _previous from public.email_verifications where scholar = _caller;
+	if _previous is not null and _previous > now() - interval '1 minute' then
+		raise exception 'Please wait a moment before requesting another verification email' using hint = 'cooldown';
+	end if;
+
+	_token := encode(extensions.gen_random_bytes(32), 'hex');
+
+	insert into public.email_verifications (scholar, token_hash, candidate_email, created_at, expires_at)
+	values (
+		_caller,
+		encode(extensions.digest(_token, 'sha256'), 'hex'),
+		lower(btrim(_email)),
+		now(),
+		now() + interval '15 minutes'
+	)
+	on conflict (scholar) do update
+		set token_hash = excluded.token_hash,
+			candidate_email = excluded.candidate_email,
+			created_at = excluded.created_at,
+			expires_at = excluded.expires_at;
+
+	-- scholar AND sender are deliberately null: the emails SELECT policy grants reads to
+	-- both the recipient and the sender, so attributing this row to the requester would let
+	-- them read the token back out of the args — the very leak this design closes. With
+	-- both null no policy branch matches and the row is unreadable by anyone.
+	insert into public.emails (event, scholar, sender, venue, email, subject, message, args)
+	values (
+		'VerifyEmail',
+		null,
+		null,
+		null,
+		lower(btrim(_email)),
+		null,
+		null,
+		jsonb_build_array(rtrim(_origin, '/') || '/verify/' || _token)
+	);
+end;
+$$;
+
+alter function public.request_email_verification (text) OWNER to "postgres";
+
+revoke execute on function public.request_email_verification (text)
+from
+	public,
+	anon;
+
+grant execute on function public.request_email_verification (text) to authenticated;

--- a/supabase/schemas/email_verifications.sql
+++ b/supabase/schemas/email_verifications.sql
@@ -63,6 +63,11 @@ alter table public.email_verifications ENABLE row LEVEL SECURITY;
 -- Does NOT touch scholars.email — the old verified value is kept until the new address is
 -- confirmed. Doubles as the "resend" and "change email" entry point (upsert on the scholar
 -- primary key resets the token and the 15-minute clock).
+--
+-- Each failure carries a machine-readable `hint` so the interface can say which of the four
+-- things went wrong. Without it every case collapsed into one generic "unable to send",
+-- which told a rate-limited scholar nothing and made a missing vault secret look like a
+-- transient delivery fault.
 create or replace function public.request_email_verification (_email text) RETURNS void LANGUAGE "plpgsql" SECURITY DEFINER
 set
 	"search_path" to 'public', 'pg_temp' as $$
@@ -73,20 +78,20 @@ declare
 	_previous timestamptz;
 begin
 	if _caller is null then
-		raise exception 'Authentication required';
+		raise exception 'Authentication required' using hint = 'auth_required';
 	end if;
 	if _email is null or _email !~ '^.+@.+\..+$' then
-		raise exception 'A valid email address is required';
+		raise exception 'A valid email address is required' using hint = 'invalid_email';
 	end if;
 	if _origin is null or _origin = '' then
-		raise exception 'The site_url vault secret is not configured';
+		raise exception 'The site_url vault secret is not configured' using hint = 'not_configured';
 	end if;
 
 	-- Rate limit. Each call emails an address the caller chose, so without a cooldown this
 	-- RPC is a mail amplifier. One per minute is well below any legitimate resend cadence.
 	select created_at into _previous from public.email_verifications where scholar = _caller;
 	if _previous is not null and _previous > now() - interval '1 minute' then
-		raise exception 'Please wait a moment before requesting another verification email';
+		raise exception 'Please wait a moment before requesting another verification email' using hint = 'cooldown';
 	end if;
 
 	_token := encode(extensions.gen_random_bytes(32), 'hex');


### PR DESCRIPTION
Three independent problems found while verifying [#139](https://github.com/reciprocalreviews/reciprocalapp/pull/139) against staging. None are regressions from that PR — the first two were exposed by it, the third is pre-existing on `dev`.

## 1. Verification errors were indistinguishable

`request_email_verification` distinguishes four failure modes, but every one of them reached the interface as the same sentence: **"Unable to send a verification email."** A rate-limited scholar was given no reason to try again, and an environment missing its `site_url` vault secret looked identical to a transient fault.

This was found the hard way: staging returned that message with an empty inbox and nothing to act on. The cause was a missing `site_url` secret, which the interface had no way to say.

Each raise now carries a machine-readable `hint`, which PostgREST returns in the error body:

| hint | message |
|---|---|
| `not_configured` | This site isn't set up to send email yet. Please report this to an administrator. |
| `cooldown` | You just requested a link — check your inbox, or try again in a minute. |
| `invalid_email` | (the existing field validation message) |
| `auth_required` | You've been signed out. Sign in again to verify your email. |

Keyed on `hint` rather than message text, so wording stays free to change and to be localized without breaking the mapping. Anything unrecognized falls back to the generic message — a new failure mode should read as a generic fault, never as the wrong specific one.

Testing surfaced one non-obvious case: a signed-out caller never reaches the function's own auth check, because `EXECUTE` is revoked from `anon`, so Postgres refuses first with `42501` and no hint. Handled explicitly.

## 2. Sticky chrome could make controls unclickable

`Nav` and `Footer` are both `position: sticky`. A control near the end of a long page could end up permanently beneath the footer — visible, but impossible to click, with no scroll position that frees it.

This hit the contact-email form on an unverified profile whenever three banners stacked (beta + test environment + unverified email), which is exactly the onboarding path #139 adds. It reproduced deterministically: with `PUBLIC_ENV=test` two e2e tests failed; with `dev` they passed.

Adds `scroll-padding` on the scrollport and `padding-block-end` on `main`. This also repairs the heading anchor links (the 🔗 icons), which have always scrolled their target underneath the sticky nav on every page.

The tests are deliberately unchanged. Making them `force: true` would have gone green without fixing anything, and the suite would have stopped reporting a real problem.

## 3. An unhandled rejection crashed the server

Found by accident when the preview server died mid-run, taking 26 tests with it:

```
Error: Cannot use `cookies.set(...)` after the response has been generated
    at setAll (src/hooks.server.ts)
    at applyServerStorage (@supabase/ssr)
    at SupabaseAuthClient._notifyAllSubscribers (@supabase/auth-js)
```

Supabase refreshes a token asynchronously; it resolves after the response has been generated, and SvelteKit throws when cookies are set that late. Nothing awaits that promise, so it becomes an **unhandled rejection that takes down the Node process**.

This is pre-existing on `dev` and affects a real request path, not just tests. Now guarded: there is nothing to do about a session written too late — the response is already on its way and the client refreshes on the next request — so it's swallowed rather than allowed to crash.

## Verification

`svelte-check` 0 errors (674 files) · unit **16** · pgTAP **302** · e2e **75/75**

All four hints were confirmed round-tripping from Postgres, including `not_configured` reproduced by deleting the vault secret locally. The e2e suite was also run under `PUBLIC_ENV=test` — stricter than CI, which runs `dev` — to confirm the layout fix against the original reproduction. The server now survives a full run.

## Deployment

No new configuration. Note that staging still needs its **`site_url`** vault secret set (step 5 of #139) — that is the underlying cause of the failure in item 1, and this PR makes it legible rather than fixing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
