### PR TITLE
Email delivery is best effort; compose ORCID names

### DIFF
--- a/supabase/migrations/20260720010000_email_delivery_best_effort_and_orcid_name.sql
+++ b/supabase/migrations/20260720010000_email_delivery_best_effort_and_orcid_name.sql
@@ -1,0 +1,122 @@
+-- Two fixes found while verifying staging.
+--
+-- 1. Email delivery must never abort the caller's transaction.
+--
+--    send_email() guarded the secret key but handed the URL straight to net.http_post, so a
+--    deployment problem became a hard failure for whoever happened to be queuing the email.
+--    Observed on staging twice: a missing `supabase_url` raised 23502 (null value in
+--    http_request_queue.url), and a value pasted with a trailing newline raised XX000
+--    ("URL using bad/illegal format"). Either way the trigger raised, the INSERT rolled
+--    back, and the RPC that queued the email failed.
+--
+--    The blast radius is much wider than email verification. Any action that queues mail —
+--    volunteering, proposing a venue, declining a transaction — would fail outright and
+--    roll back the user's actual work, on a project whose only fault is a mistyped secret.
+--
+--    Delivery is now best effort: the row in public.emails is the durable record that a
+--    message was meant to go out, and reaching the edge function is a deployment concern.
+--    A missing or unusable secret logs a warning and leaves the row in place; the caller's
+--    work commits. Secrets are trimmed, so whitespace pasted into the Vault stops mattering.
+--
+-- 2. ORCID supplies given_name/family_name, never `name`.
+--
+--    handle_new_scholar read `raw_user_meta_data->>'name'`, which ORCID does not send, so
+--    every scholar created through ORCID sign-in got a null name. Confirmed against a real
+--    staging account: the metadata keys are sub, given_name, family_name, iss, aud, iat,
+--    exp, email_verified, phone_verified. `name` is preferred when a provider does send it,
+--    with given/family composed as the fallback.
+--------------------------------------
+-- 1. Best-effort delivery.
+create or replace function public.send_email () returns trigger language plpgsql security definer
+set
+	"search_path" to '' as $$
+declare
+  -- btrim so a secret pasted with a stray newline or space still works. That exact mistake
+  -- cost an afternoon of debugging on staging.
+  _key text := btrim(coalesce(private.get_secret('secret_key'), private.get_secret('service_role_key'), ''));
+  _url text := btrim(coalesce(private.get_secret('supabase_url'), ''));
+begin
+  -- Not configured: record the email, warn, and let the caller's transaction commit.
+  if _key = '' or _url = '' then
+    raise warning 'send_email: % is not configured, so email % was recorded but not delivered',
+      case when _url = '' then 'the supabase_url vault secret' else 'the secret_key vault secret' end,
+      new.id;
+    return new;
+  end if;
+
+  -- Configured but unreachable, malformed, or otherwise failing: same principle. pg_net
+  -- validates the URL synchronously, so a bad value raises here rather than in the
+  -- background worker — and without this handler that raise propagates into the caller.
+  begin
+    perform net.http_post(
+      url:=replace(_url, '127.0.0.1', 'host.docker.internal') || '/functions/v1/resend',
+      headers:=jsonb_build_object(
+          'Content-Type', 'application/json',
+          'apikey', _key
+      )::jsonb,
+      body:=jsonb_build_object(
+        'to', new.email,
+        'subject', new.subject,
+        'message', new.message,
+        'event', new.event,
+        'args', new.args
+      )
+    );
+  exception when others then
+    raise warning 'send_email: email % was recorded but could not be queued for delivery: % (%)',
+      new.id, sqlerrm, sqlstate;
+  end;
+
+  return new;
+end;
+$$;
+
+alter function public.send_email () OWNER to "postgres";
+
+--------------------------------------
+-- 2. Compose the scholar's name from whatever the provider actually sends.
+create or replace function public.handle_new_scholar () returns "trigger" language "plpgsql" security definer
+set
+	"search_path" to '' as $$
+begin
+  insert into public.scholars (id, orcid, name)
+  values (
+    new.id,
+    coalesce(
+      new.raw_user_meta_data->>'orcid',
+      new.raw_user_meta_data->>'provider_id',
+      new.raw_user_meta_data->>'sub'
+    ),
+    -- ORCID sends given_name/family_name and no `name`. Prefer `name` for providers that do
+    -- send it; fall back to the composed form. Left null when the provider sends neither,
+    -- so the scholar can supply one rather than being given a placeholder.
+    coalesce(
+      nullif(btrim(new.raw_user_meta_data->>'name'), ''),
+      nullif(btrim(concat_ws(' ',
+        new.raw_user_meta_data->>'given_name',
+        new.raw_user_meta_data->>'family_name'
+      )), '')
+    )
+  );
+  return new;
+end;
+$$;
+
+alter function public.handle_new_scholar () OWNER to "postgres";
+
+-- Backfill scholars already created without a name, using the same rule.
+update public.scholars s
+set
+	name = coalesce(
+		nullif(btrim(u.raw_user_meta_data ->> 'name'), ''),
+		nullif(btrim(concat_ws(' ', u.raw_user_meta_data ->> 'given_name', u.raw_user_meta_data ->> 'family_name')), '')
+	)
+from
+	auth.users u
+where
+	u.id = s.id
+	and s.name is null
+	and coalesce(
+		nullif(btrim(u.raw_user_meta_data ->> 'name'), ''),
+		nullif(btrim(concat_ws(' ', u.raw_user_meta_data ->> 'given_name', u.raw_user_meta_data ->> 'family_name')), '')
+	) is not null;

--- a/supabase/schemas/emails.sql
+++ b/supabase/schemas/emails.sql
@@ -128,41 +128,52 @@ alter function private.get_secret (secret_name text) OWNER to "postgres";
 -- arguments from the request — callable by anyone as an open relay for branded mail. The
 -- function authorizes by comparing the presented key against the project's secret keys
 -- (supabase/functions/_shared/auth.ts), which works for both a legacy `service_role` JWT
--- and a newer opaque `sb_secret_...` key.
---
--- The key goes on the `apikey` header: `Authorization: Bearer` is reserved for JWTs, and a
--- new-format key sent there is rejected as an invalid JWT. Hosted projects must have the
--- `secret_key` vault secret set by hand; local dev seeds it from SUPABASE_SECRET_KEY via
--- [db.vault] in supabase/config.toml.
+-- and a newer opaque `sb_secret_...` key. Hosted projects must have the `secret_key` and
+-- `supabase_url` vault secrets set by hand; local dev seeds them from [db.vault] in
+-- supabase/config.toml.
 create or replace function public.send_email () RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER
 set
 	"search_path" to '' as $$
 declare
-  -- Prefer the new name, falling back to the pre-rename one so this is safe to deploy
-  -- before a hosted project's vault secret is renamed.
-  _key text := coalesce(private.get_secret('secret_key'), private.get_secret('service_role_key'));
+  -- btrim so a secret pasted with a stray newline or space still works.
+  _key text := btrim(coalesce(private.get_secret('secret_key'), private.get_secret('service_role_key'), ''));
+  _url text := btrim(coalesce(private.get_secret('supabase_url'), ''));
 begin
-  -- Surface a misconfigured deployment in the Postgres logs. pg_net posts
-  -- asynchronously and swallows failures, so without this a missing secret would look
-  -- exactly like mail silently not arriving.
-  if _key is null or _key = '' then
-    raise warning 'send_email: no secret_key vault secret is configured, so email % cannot be delivered', new.id;
+  -- Delivery is BEST EFFORT. The row in public.emails is the durable record that a message
+  -- was meant to go out; whether the edge function can be reached is a deployment concern
+  -- and must never roll back the caller's transaction. Before this, a missing or malformed
+  -- supabase_url raised here and failed whatever action had queued the mail — volunteering,
+  -- proposing a venue, verifying an email — on a project whose only fault was a bad secret.
+  if _key = '' or _url = '' then
+    raise warning 'send_email: % is not configured, so email % was recorded but not delivered',
+      case when _url = '' then 'the supabase_url vault secret' else 'the secret_key vault secret' end,
+      new.id;
+    return new;
   end if;
-  -- Post to the Resend edge function. If the supabase URL is set to localhost, replace it with host.docker.internal so we hit the host machine, not the container.
-  perform net.http_post(
-    url:=replace(private.get_secret('supabase_url'), '127.0.0.1', 'host.docker.internal') || '/functions/v1/resend',
-    headers:=jsonb_build_object(
-        'Content-Type', 'application/json',
-        'apikey', _key
-    )::jsonb,
-    body:=jsonb_build_object(
-      'to', new.email,
-      'subject', new.subject,
-      'message', new.message,
-      'event', new.event,
-      'args', new.args
-    )
-  );
+  begin
+    -- Post to the Resend edge function. If the supabase URL is set to localhost, replace it with host.docker.internal so we hit the host machine, not the container.
+    -- The key goes on `apikey`: `Authorization: Bearer` is reserved for JWTs, and the newer
+    -- opaque `sb_secret_...` keys are rejected there.
+    perform net.http_post(
+      url:=replace(_url, '127.0.0.1', 'host.docker.internal') || '/functions/v1/resend',
+      headers:=jsonb_build_object(
+          'Content-Type', 'application/json',
+          'apikey', _key
+      )::jsonb,
+      body:=jsonb_build_object(
+        'to', new.email,
+        'subject', new.subject,
+        'message', new.message,
+        'event', new.event,
+        'args', new.args
+      )
+    );
+  exception when others then
+    -- pg_net validates the URL synchronously, so a malformed value raises here rather than
+    -- in the background worker. Warn and carry on.
+    raise warning 'send_email: email % was recorded but could not be queued for delivery: % (%)',
+      new.id, sqlerrm, sqlstate;
+  end;
   return new;
 end;
 $$;

--- a/supabase/schemas/scholars.sql
+++ b/supabase/schemas/scholars.sql
@@ -94,7 +94,15 @@ begin
       new.raw_user_meta_data->>'provider_id',
       new.raw_user_meta_data->>'sub'
     ),
-    new.raw_user_meta_data->>'name'
+    -- ORCID sends given_name/family_name and no `name`. Prefer `name` for providers that
+    -- do send it; fall back to the composed form. Left null when neither is present.
+    coalesce(
+      nullif(btrim(new.raw_user_meta_data->>'name'), ''),
+      nullif(btrim(concat_ws(' ',
+        new.raw_user_meta_data->>'given_name',
+        new.raw_user_meta_data->>'family_name'
+      )), '')
+    )
   );
   -- Return the new row.
   return new;


### PR DESCRIPTION
Two problems found while verifying staging, both confirmed against a real hosted project rather than inferred.

## 1. Email delivery could abort the caller's transaction

`send_email()` guarded the secret key but handed the URL straight to `net.http_post`. `pg_net` validates the URL **synchronously**, so a deployment problem raised inside the trigger, rolled back the `INSERT`, and failed the RPC that queued the mail.

Both variants actually happened on staging:

| `supabase_url` | SQLSTATE | Surfaced as |
|---|---|---|
| missing | `23502` — null value in `http_request_queue.url` | "Unable to send a verification email" |
| pasted with a trailing newline | `XX000` — URL using bad/illegal format | "Unable to send a verification email" |

Neither carries a hint, so both fell through the mapping added in #140 to the generic message — which is why that PR didn't make this diagnosable. The diagnostics were real but scoped to the failures the *function* raises, not the ones the *trigger* underneath it raises.

**The blast radius is much wider than email verification.** Any action that queues mail — volunteering, proposing a venue, declining a transaction, approving a proposal — would fail outright and roll back the user's actual work, on a project whose only fault is a mistyped secret.

Delivery is now best effort. The row in `public.emails` is the durable record that a message was meant to go out; whether the edge function is reachable is a deployment concern. An unusable secret logs a warning naming the email id and the reason, and the caller's transaction commits. Secrets are `btrim`ed, so whitespace pasted into the Vault stops mattering.

Verified — with a deliberately malformed URL:

```
WARNING: send_email: email 87749b71-… was recorded but could not be queued
         for delivery: URL using bad/illegal format or missing URL (XX000)
emails recorded: 1     verification pending: 1     caller: committed
```

A genuinely missing `site_url` still raises with `hint=not_configured`, because that one *is* the caller's problem — no link can be built. That distinction is deliberate and covered.

## 2. ORCID sign-in produced scholars with no name

`handle_new_scholar` read `raw_user_meta_data->>'name'`, which ORCID never sends. Every scholar created through ORCID sign-in got a null name.

Confirmed by inspecting a real staging account — the metadata keys are exactly:

```
sub, given_name, family_name, iss, aud, iat, exp, email_verified, phone_verified
```

`name` is still preferred for providers that do send it, with `given_name` + `family_name` composed as the fallback, and left null if neither is present rather than inventing a placeholder. Existing null rows are backfilled by the same rule.

Verified against the exact staging metadata shape: composes `Amy Ko`, ORCID iD preserved.

## Verification

`svelte-check` 0 errors (675 files) · pgTAP **302** · e2e **75/75**

Both failure modes were reproduced locally first, then re-run against the fix.

## Deployment

No new configuration. Staging's `site_url` and `supabase_url` are already corrected; this PR means a future mistake there degrades to "mail didn't send" instead of "your action failed."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
