### PR TITLE
Enable pg_net

### DIFF
--- a/supabase/migrations/20260720020000_enable_pg_net.sql
+++ b/supabase/migrations/20260720020000_enable_pg_net.sql
@@ -1,0 +1,22 @@
+-- Enable pg_net, which the email pipeline has always assumed and never declared.
+--
+-- public.send_email() and the remind-daily cron job both call net.http_post to reach the
+-- edge functions. Nothing in this repository ever created the extension: the local stack
+-- enables pg_net on its own, so every developer machine and every CI run had it, and the
+-- omission was invisible. Hosted projects do not enable it automatically.
+--
+-- Consequence on staging: `net.http_post` did not exist, so the AFTER INSERT trigger on
+-- public.emails raised, the INSERT rolled back, and the RPC that queued the mail failed.
+-- That is the real origin of "Unable to send a verification email" — not the vault secrets
+-- that were investigated first. Not one email had ever left that project.
+--
+-- 20260720010000 made delivery best effort, which turned the hard failure into a warning:
+-- the row is now recorded and the caller succeeds, but with pg_net absent no request is
+-- ever made. Both changes are wanted. This one restores delivery; that one keeps a
+-- deployment fault from destroying the user's work.
+--
+-- pg_net owns the `net` schema, which is where send_email() and the cron command look for
+-- http_post, so it is created without a schema override. `if not exists` makes this a
+-- no-op wherever the extension is already present, including local development and CI.
+
+create extension if not exists pg_net;


### PR DESCRIPTION
## `pg_net` was never enabled on hosted projects

`public.send_email()` and the `remind-daily` cron job both call `net.http_post`. Nothing in this repository ever created the extension. The local stack enables `pg_net` automatically, so every developer machine and every CI run had it — and the omission was invisible for as long as nobody looked at a hosted project.

Staging's installed extensions:

```
pg_cron, pg_stat_statements, pgcrypto, pgjwt, pgsodium, plpgsql, supabase_vault, uuid-ossp
```

No `pg_net`. **No email has ever left that project.**

## Why this took so long to find

Before [#141](https://github.com/reciprocalreviews/reciprocalapp/pull/141), a missing `net.http_post` made the AFTER INSERT trigger raise, rolled back the `INSERT`, and failed the RPC that queued the mail — surfacing as "Unable to send a verification email" with no detail. That is the real origin of the staging failure, not the vault secrets that were investigated first.

The vault problems found along the way were genuine and worth fixing — a trailing newline in `supabase_url`, and a literal `site_url` in `[db.vault]` that `supabase db push` copied over the hosted value on every deploy — but neither was the original cause. They were diagnosed by reproducing locally, because Cloudflare blocks writes through the Management API and the staging error itself could not be read.

#141 then made delivery best effort, which converted the hard failure into a warning: the row is recorded, the caller succeeds, and with `pg_net` absent no request is ever made. That is why the interface began reporting success while the inbox stayed empty.

Both behaviors are wanted. This PR restores delivery; #141 keeps a deployment fault from destroying the user's work.

## The fix

```sql
create extension if not exists pg_net;
```

`pg_net` owns the `net` schema, which is where `send_email()` and the cron command look for `http_post`, so it is created without a schema override. `if not exists` makes it a no-op wherever the extension is already present — local development and CI included.

## Verification

Migration applies cleanly; `pg_net v0.14.0` was already present locally, so it is a genuine no-op there. pgTAP **302** pass.

The e2e suite was not re-run: on a machine that already has the extension this changes nothing, so it would exercise identical code paths. The meaningful verification is on staging after deploy — an `emails` row should now produce an actual delivery attempt rather than a warning.

## After merging

Retry the send on staging. If mail still does not arrive, the failure has moved to Resend itself (sender domain verification, or recipient restrictions on the account), which is the one link in this chain that has never been exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
