### PR TITLE
Surface Resend rejections instead of reporting success

### DIFF
--- a/supabase/functions/remind/index.ts
+++ b/supabase/functions/remind/index.ts
@@ -198,6 +198,11 @@ const handler = async (request: Request): Promise<Response> => {
 		const statusReminders = await getStaleStatusReminder(supabase);
 		const transactionsReminders = await getTransactionReminders(supabase);
 
+		// Reminders are sent one per recipient, so one rejection should not abandon the rest
+		// of the run. Count them instead and report at the end — a cron job that reports
+		// success while silently delivering nothing is the failure mode worth avoiding.
+		let rejected = 0;
+
 		for (const email of [...statusReminders, ...transactionsReminders]) {
 			const { to, subject, message } = email;
 
@@ -227,9 +232,22 @@ const handler = async (request: Request): Promise<Response> => {
 						text
 					})
 				});
-				// Wait for the email to sent.
-				await res.json();
+				// `fetch` does not throw on 4xx/5xx, so an unverified sender domain or a
+				// rejected recipient would otherwise pass silently.
+				const data = await res.json().catch(() => null);
+				if (!res.ok) {
+					rejected++;
+					console.error('Resend rejected a reminder', res.status, to, data);
+				}
 			}
+		}
+
+		const attempted = statusReminders.length + transactionsReminders.length;
+		if (rejected > 0) {
+			return new Response(
+				JSON.stringify({ error: 'Resend rejected reminders', rejected, attempted }),
+				{ status: 502, headers: { 'Content-Type': 'application/json' } }
+			);
 		}
 
 		// Respond with success.

--- a/supabase/functions/resend/index.ts
+++ b/supabase/functions/resend/index.ts
@@ -83,8 +83,20 @@ const handler = async (request: Request): Promise<Response> => {
 				})
 			});
 
-			// Wait for the email to sent.
-			const data = await res.json();
+			// Resend answers 4xx/5xx with a JSON body explaining why — an unverified sender
+			// domain, a rejected recipient, a rate limit, a bad key. `fetch` does not throw
+			// for those, so without this check the rejection was parsed, stringified, and
+			// returned as a 200: the caller saw success and the mail silently never arrived.
+			// Fail loudly instead. pg_net records the status, so a refused send is visible in
+			// net._http_response rather than being indistinguishable from a delivered one.
+			const data = await res.json().catch(() => null);
+			if (!res.ok) {
+				console.error('Resend rejected the message', res.status, data);
+				return new Response(
+					JSON.stringify({ error: 'Resend rejected the message', status: res.status, data }),
+					{ status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+				);
+			}
 			returnData = JSON.stringify(data);
 		}
 


### PR DESCRIPTION
Both edge functions posted to the Resend API and never checked `res.ok`. `fetch` does not throw for 4xx/5xx, so a rejection — an unverified sender domain, a refused recipient, a rate limit, a bad key — was parsed, stringified, and returned as a **200**. The caller saw success and the mail silently never arrived.

Given how much of the staging bring-up was spent chasing invisible failures, this one was worth closing before production.

## Changes

**`resend`** returns **502** with Resend's status and body. `pg_net` records the status, so a refused send is now distinguishable from a delivered one in `net._http_response` rather than looking identical.

**`remind`** counts rejections instead of abandoning the run at the first one, then reports 502 if any occurred. Reminders are one-per-recipient, so a single bad address shouldn't silence the rest — but a cron job that claims success while delivering nothing is the failure mode worth avoiding.

## Verification

Exercised against a **real Resend rejection** by forcing the non-local branch with an invalid key:

```
{"error":"Resend rejected the message","status":401,
 "data":{"statusCode":401,"name":"validation_error","message":"API key is invalid"}}
HTTP 502
```

That exact response was previously a 200. Caller authorization still returns 403 without a secret key. Both functions `deno check` clean.

The e2e suite was not re-run: CI excludes the edge runtime, and the local isLocal branch (which logs instead of sending) is untouched, so no test exercises this path either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)