### PR TITLE
Let production be tested before launch

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -28,9 +28,39 @@
 
 	const inProd = PUBLIC_ENV === 'prod';
 
-	/** Always go home in production, pre-release */
+	/**
+	 * Pre-release, production sends every page back to the landing page. Two exceptions,
+	 * both needed to exercise the ORCID and email-verification flow against production
+	 * before launch (#19, #27):
+	 *
+	 * - Visiting any page with `?test` unlocks the rest of the app in this browser until
+	 *   local storage is cleared. A query string cannot survive the redirects the flow
+	 *   performs — /auth/callback sends you to /scholar/[id] — so the unlock is remembered
+	 *   rather than re-checked per page. `/login?test` is the intended entry point. Local
+	 *   rather than session storage because sessionStorage is per-tab, so opening any link
+	 *   in a new tab would silently re-lock the site mid-test.
+	 * - /verify is always reachable. That link arrives by email and is routinely opened on a
+	 *   different device from the one that requested it, where no unlock could exist.
+	 *
+	 * This is a curtain, not a control. `?test` is guessable, and anyone past it can sign in
+	 * with their own ORCID iD and create a real scholar record in production. What actually
+	 * protects data is ORCID authentication and RLS; this only keeps the unlaunched site from
+	 * being wandered into. Remove the whole block at launch.
+	 *
+	 * /auth/callback needs no exception: it is a +server.ts endpoint, so this layout never
+	 * mounts for it.
+	 */
+	const PREVIEW_UNLOCK = 'rr-preview-unlock';
+
 	onMount(() => {
-		if (inProd && !['/updates', '/about'].some((p) => page.url.pathname.startsWith(p))) goto('/');
+		if (inProd) {
+			if (page.url.searchParams.has('test')) localStorage.setItem(PREVIEW_UNLOCK, 'yes');
+			const unlocked = localStorage.getItem(PREVIEW_UNLOCK) === 'yes';
+			// Ignore a leading locale prefix, so /en/updates is treated like /updates.
+			const path = page.url.pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '') || '/';
+			const alwaysOpen = ['/updates', '/about', '/verify'].some((p) => path.startsWith(p));
+			if (!alwaysOpen && !unlocked) goto('/');
+		}
 
 		// Listen to auth state changes and invalidate the auth context when they happen.
 		const { data } = db.client.auth.onAuthStateChange((event, _session) => {


### PR DESCRIPTION
Pre-release, production redirects every page to the landing page, so there is no way to exercise ORCID sign-in and email verification against the real project.

## Behavior

Visiting any page with `?test` unlocks the rest of the app in that browser. `/login?test` is the intended entry point.

The unlock is **remembered** rather than re-checked per page, because a query string cannot survive the redirects the flow performs — `/auth/callback` sends you on to `/scholar/[id]`. It uses **local** rather than session storage: `sessionStorage` is per-tab, so opening any link in a new tab would silently re-lock the site mid-test. I hit exactly that while testing the first version of this.

`/verify` is **always** reachable, with no unlock. That link arrives by email and is routinely opened on a different device from the one that requested it, where no unlock could exist.

`/auth/callback` needs no exception — it is a `+server.ts` endpoint, so this layout never mounts for it.

## This is a curtain, not a control

`?test` is guessable, and anyone past it can sign in with their own ORCID iD and create a real scholar record in production. What protects data is ORCID authentication and RLS; this only keeps the unlaunched site from being wandered into. The comment in the source says so, and says to remove the block at launch.

## Verification

Nothing in the test suite covers this gate — every test runs at `PUBLIC_ENV=dev`, so `inProd` is never true. It was verified in a real browser against a `PUBLIC_ENV=prod` build:

```
locked browser
  PASS  login blocked                    /login       -> /
  PASS  scholar blocked                  /scholar/abc -> /
  PASS  about always open                /about       -> /about
  PASS  verify always open (email link)  /verify/tok  -> /verify/tok
unlock, then continue in the SAME tab (the real flow)
  PASS  login?test entry                 /login?test  -> /login?test
  PASS  scholar after unlock             /scholar/abc -> /scholar/abc
  PASS  venues after unlock              /venues      -> /venues
unlock survives a NEW tab (why localStorage)
  PASS  scholar in new tab               /scholar/abc -> /scholar/abc
a different browser is still locked
  PASS  scholar, unrelated visitor       /scholar/abc -> /
```

Also `svelte-check` 0 errors across 675 files. Targets `main` directly, since it only matters in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)