### PR TITLE
42 inactive venues

### DIFF
--- a/src/lib/locales/Locale.ts
+++ b/src/lib/locales/Locale.ts
@@ -140,6 +140,7 @@ export type LocaleText = {
 			title: string;
 			description: string;
 			header: {
+				inactive: string;
 				proposed: string;
 				active: string;
 			};
@@ -147,6 +148,7 @@ export type LocaleText = {
 				propose: string;
 			};
 			feedback: {
+				noInactiveVenues: string;
 				noVenues: string;
 				venuesNotLoaded: string;
 				noProposals: string;

--- a/src/lib/locales/LocaleText.json
+++ b/src/lib/locales/LocaleText.json
@@ -4452,6 +4452,9 @@
                 "feedback": {
                   "additionalProperties": false,
                   "properties": {
+                    "noInactiveVenues": {
+                      "type": "string"
+                    },
                     "noProposals": {
                       "type": "string"
                     },
@@ -4466,6 +4469,7 @@
                     }
                   },
                   "required": [
+                    "noInactiveVenues",
                     "noVenues",
                     "venuesNotLoaded",
                     "noProposals",
@@ -4602,11 +4606,15 @@
                     "active": {
                       "type": "string"
                     },
+                    "inactive": {
+                      "type": "string"
+                    },
                     "proposed": {
                       "type": "string"
                     }
                   },
                   "required": [
+                    "inactive",
                     "proposed",
                     "active"
                   ],

--- a/src/routes/[[lang]]/venues/+page.svelte
+++ b/src/routes/[[lang]]/venues/+page.svelte
@@ -12,6 +12,7 @@
 
 	let proposals = $derived(data.proposals);
 	let venues = $derived(data.venues);
+	let inactiveVenues = $derived(data.inactiveVenues);
 
 	const auth = getAuth();
 </script>
@@ -25,20 +26,18 @@
 
 	<Subheader icon={VenueLabel} text={(l) => l.page.venues.header.active} />
 
-	{#if venues}
-		{#if venues.length > 0}
-			<ul>
-				{#each venues.toSorted((a, b) => a.title.localeCompare(b.title)) as venue, index}
-					<li>
-						<VenueLink id={venue.id} name={venue.title} testid={'venue-' + index}></VenueLink>
-					</li>
-				{/each}
-			</ul>
-		{:else}
-			<Feedback text={(l) => l.page.venues.feedback.noVenues} />
-		{/if}
-	{:else}
+	{#if venues === null}
 		<Feedback error text={(l) => l.page.venues.feedback.venuesNotLoaded} />
+	{:else if venues.length > 0}
+		<ul>
+			{#each venues.toSorted((a, b) => a.title.localeCompare(b.title)) as venue, index}
+				<li>
+					<VenueLink id={venue.id} name={venue.title} testid={'venue-' + index}></VenueLink>
+				</li>
+			{/each}
+		</ul>
+	{:else}
+		<Feedback text={(l) => l.page.venues.feedback.noVenues} />
 	{/if}
 
 	<Subheader icon={VenueLabel} text={(l) => l.page.venues.header.proposed} />
@@ -59,5 +58,20 @@
 		{/if}
 	{:else}
 		<Feedback error text={(l) => l.page.venues.feedback.proposalsNotLoaded} />
+	{/if}
+
+	{#if inactiveVenues !== null && inactiveVenues.length > 0}
+		<Subheader icon={VenueLabel} text={(l) => l.page.venues.header.inactive} />
+
+		<ul>
+			{#each inactiveVenues.toSorted((a, b) => a.title.localeCompare(b.title)) as venue, index}
+				<li data-testid={'inactive-venue-' + index}>
+					{venue.title}
+					{#if venue.inactive}
+						<span class="inactive-note">({venue.inactive})</span>
+					{/if}
+				</li>
+			{/each}
+		</ul>
 	{/if}
 </Page>

--- a/src/routes/[[lang]]/venues/+page.ts
+++ b/src/routes/[[lang]]/venues/+page.ts
@@ -4,10 +4,11 @@ export const load: PageLoad = async ({ parent }) => {
 	const { db } = await parent();
 
 	const { data: proposals } = await db.getUnassignedProposals();
-	const { data: venues } = await db.getVenues();
+	const { data: allVenues } = await db.getVenues();
 
 	return {
 		proposals,
-		venues
+		venues: allVenues?.filter((v) => v.inactive === null) ?? null,
+		inactiveVenues: allVenues?.filter((v) => v.inactive !== null) ?? null
 	};
 };

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -93,7 +93,8 @@
             "description": "These are journals and conferences using Reciprocal Reviews to track and incentivize peer review. Choose one to see it's policies or volunteer to review for it, or propose a new one.",
             "header": {
                 "proposed": "Proposed venues",
-                "active": "Active venues"
+                "active": "Active venues",
+                "inactive": "Inactive venues"
             },
             "link": {
                 "propose": "Propose a new venue"
@@ -102,7 +103,8 @@
                 "noVenues": "There are no active venues.",
                 "venuesNotLoaded": "We couldn't load the venues.",
                 "noProposals": "No venues have been proposed yet.",
-                "proposalsNotLoaded": "We couldn't load the venue proposals."
+                "proposalsNotLoaded": "We couldn't load the venue proposals.",
+                "noInactiveVenues": "There are no inactive venues."
             },
             "field": {
                 "title": {

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -567,7 +567,7 @@ values
 		'c60c9fca-ad37-11f0-a9a1-57b72e1e85ac',
 		'20',
 		'{"d181d165-8b6a-4d79-ad28-a9aece21d813"}',
-		null
+		'March 2027'
 	);
 
 insert into


### PR DESCRIPTION
Hello, I made a new branch and pull request for this feature (issue #42) because the last branch and pr (pr #146) was very messy. I also addressed all the points of feedback from the last pr with my implementation notes here below. I will add a screenshot of the venues page as well.

<img width="1456" height="912" alt="inactive_venues" src="https://github.com/user-attachments/assets/3cbda5ac-7ab7-496d-9555-13495b9b8ac6" />


**Fixed duplicated error string. Renders one error for the whole venues fetch.**
- Removed venuesFailedToLoad flag.
- Checks for feedback.venuesNotLoaded once in active venues.
- Removed noInactiveVenues feedback message.

**Surfaced inactive message in inactive venue list. Removed the VenueLink component from inactive venues.**
- I used an if statement to handle an empty string (no inactive note) from the seed.sql.

**Ordered the subheaders properly, made the inactive section hidden when empty.**
- Moved inactive venues subheader under the if inactive venues is not null and greater than 0 block so that the inactive venues section will be hidden if empty.

**Fixed load error path dead code issue.**
- Changed from ?? [] to ?? null in page.ts.
- If a query fails and allVenues data is null, venues and inactive venues will both become null and render the venuesNotLoaded error once.

**Ran prettier formatting on page.svelte and page.ts.**

**Ran npm locale-schema, committed my localeText.json edits adding inactive venue strings.**

**Caught up to dev.**
