### PR TITLE
Close the gap under the banners before hydration

### DIFF
--- a/src/lib/components/Page.svelte
+++ b/src/lib/components/Page.svelte
@@ -107,11 +107,24 @@
 <style>
 	.page-header {
 		/* Pinned below the nav, which is sticky at the top of the viewport. Its height
-		   varies with banners and row wrapping, so it is measured rather than guessed;
-		   the fallback covers the first paint and a scripting-off reader. The nav keeps
-		   a higher z-index, so it wins if this offset is ever momentarily stale. */
+		   varies with banners and row wrapping, so it is measured rather than guessed.
+		   The nav keeps a higher z-index, so it wins if this offset is ever stale.
+
+		   The fallback is 0, and it has to be: a sticky box whose natural position sits
+		   ABOVE its own threshold is pushed down to meet it. So a fallback larger than
+		   the real nav height opens a visible gap between the banners and this band on
+		   every first paint, which then closes on hydration — which is exactly what an
+		   8rem guess did here when the nav measured 103px. Zero can never overshoot,
+		   because the nav is never shorter than nothing, so the band sits at its natural
+		   position until the measurement arrives and nothing moves when it does. With
+		   scripting off the band scrolls under the nav instead of pinning below it,
+		   which is a far better failure than a gap on every load.
+
+		   Note this is the opposite of how `--nav-height` is defaulted for
+		   `scroll-padding-block-start` in app.html, where guessing low would let an
+		   anchored heading land underneath the chrome. Same variable, opposite risk. */
 		position: sticky;
-		top: var(--nav-height, 8rem);
+		top: var(--nav-height, 0px);
 		z-index: 1;
 
 		/* Deliberately the full width of `main`, not the text column: the h1 is a


### PR DESCRIPTION
Follow-up to #160. The page title band briefly sat ~25px below the banners on first paint, then snapped up on hydration — not functionally broken, but it looked broken.

## Cause

`.page-header` is `position: sticky` below the nav, offset by the `--nav-height` that the `measure` action reports after mount. Until then the CSS fell back to `8rem`.

A sticky box whose natural position sits **above** its own threshold gets pushed **down** to meet it. With a real nav height of 103px and a 128px fallback, the band was shoved down 24.9px — a gap that closed the moment hydration wrote the true value.

Reproduced with scripting disabled, which is what the first paint looks like:

| | nav bottom | title top | gap | resolved `top` |
|---|---|---|---|---|
| JS off (first paint) | 103.1 | 128.0 | **24.9px** | `128px` (the 8rem fallback) |
| JS on (hydrated) | 103.1 | 103.1 | 0px | `103.141px` (measured) |

It was desktop-only: at 390px the nav wraps and measures ~159px, comfortably above the 128px fallback, so nothing was pushed down there.

## Fix

The fallback becomes `0`, which cannot overshoot — the nav is never shorter than nothing, so the band stays at its natural position until the measurement arrives, and nothing moves when it does. With scripting off the band scrolls under the nav instead of pinning below it, which is a much better failure than a gap on every load.

This is deliberately the opposite of how the same variable is defaulted for `scroll-padding-block-start` in `app.html`, where guessing *low* would let an anchored heading land underneath the chrome. Same variable, opposite risk; the comment says so.

## Verification

Gap between banners and title band, 0 = flush:

| Page / viewport | JS off | JS on |
|---|---|---|
| `/` @1280 | 0px ✓ | 0px ✓ |
| `/` @390 | 0px ✓ | 0px ✓ |
| `/help` @1280 | 0px ✓ | 0px ✓ |
| `/terms` @390 | 0px ✓ | 0px ✓ |
| `/venues` @1280 | 0px ✓ | 0px ✓ |

After scrolling 700px the band is still pinned directly below the nav. `check:now` 0 errors, `test:unit` 415 passed, `prettier --check` clean.

## Why the original verification missed it

Worth recording. #160 measured cumulative layout shift and got 0.000 — correctly. A sticky offset changes where a box *paints*, not where it sits in flow, so the band moved on screen without any layout shift to record. **CLS is not a sufficient check for sticky chrome**; comparing geometry with scripting off against scripting on is, and that is the check used here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)